### PR TITLE
tgstat.h: define MAP_ANONYMOUS for platforms where it is missing

### DIFF
--- a/src/tgstat.h
+++ b/src/tgstat.h
@@ -29,6 +29,10 @@
 
 #define TGS_EXIT_SIG SIGTERM
 
+#ifndef MAP_ANONYMOUS
+# define MAP_ANONYMOUS MAP_ANON
+#endif
+
 #include "TGLException.h"
 
 using namespace std;


### PR DESCRIPTION
Some platforms do not have MAP_ANONYMOUS (macOS < 10.11, for example, possibly some other too), fix that.