### PR TITLE
Properly link to BLAS, fixes cross compilation

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,0 +1,1 @@
+PKG_LIBS = $(BLAS_LIBS) $(FLIBS)


### PR DESCRIPTION
See the error here: https://github.com/r-universe/tanaylab/actions/runs/7502647659/job/20425812767

The problem is you are using BLAS in your code but not linking to it in your src/Makevars. For examples from other CRAN packages see: https://github.com/search?q=org%3Acran%20path%3Asrc%2FMakevars%20%24(BLAS_LIBS)&type=code