### PR TITLE
Fix configurable tmpdir and child-process hang prevention

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tgstat
 Title: Amos Tanay's Group High Performance Statistical Utilities
-Version: 2.3.29
+Version: 2.3.30
 Authors@R: c(
     person("Michael", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre"))
@@ -33,5 +33,5 @@ LazyLoad: yes
 NeedsCompilation: yes
 OS_type: unix
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# tgstat 2.3.30
+
+* FIFO temp directory is now configurable via `options(tgs_tmpdir = "/path")` or the `TMPDIR` environment variable, instead of being hardcoded to `/tmp`. Fixes permission errors on systems where `/tmp` is restricted (#17).
+* Added a child-process liveness check in `wait_for_kid()`/`wait_for_kids()` to prevent potential hangs when child processes terminate unexpectedly without being reaped (#18).
+* Added comprehensive tests for `tgs_cor_knn` and temp directory configuration.
+
 # tgstat 2.3.29
 
 * Removed non-API calls to R: `Rf_GetOption`.

--- a/R/knn.R
+++ b/R/knn.R
@@ -84,7 +84,6 @@ tgs_graph <- function(x, knn, k_expand, k_beta = 3) {
 }
 
 
-
 #' Clusters directed graph
 #'
 #' Clusters directed graph.
@@ -144,7 +143,6 @@ tgs_graph_cover <- function(graph, min_cluster_size, cooling = 1.05, burn_in = 1
 
     .Call("tgs_graph2cluster", graph, min_cluster_size, cooling, burn_in, new.env(parent = parent.frame()))
 }
-
 
 
 #' Clusters directed graph multiple times with randomized sample subset
@@ -225,7 +223,6 @@ tgs_graph_cover_resample <- function(graph, knn, min_cluster_size, cooling = 1.0
         stop("\"method\" argument must be equal to \"hash\", \"full\" or \"edges\"", call. = FALSE)
     }
 }
-
 
 
 #' Returns k highest values of each column

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,2 +1,1 @@
-.onLoad <- function(lib, pkg) {
-}
+.onLoad <- function(lib, pkg) {}

--- a/src/tgstat.cpp
+++ b/src/tgstat.cpp
@@ -1,3 +1,4 @@
+#include <climits>
 #include <ctype.h>
 #include <dirent.h>
 #include <errno.h>
@@ -61,6 +62,7 @@ int                      TGStat::s_kid_index;
 vector<pid_t>            TGStat::s_running_pids;
 TGStat::Shm             *TGStat::s_shm = (TGStat::Shm *)MAP_FAILED;
 int                      TGStat::s_fifo_fd = -1;
+string                   TGStat::s_tmpdir;
 
 TGStat *g_tgstat = NULL;
 
@@ -218,8 +220,9 @@ string TGStat::get_fifo_sem_name()
 
 string TGStat::get_fifo_name()
 {
-	char buf[100];
-    snprintf(buf, sizeof(buf), "/tmp/tgstat_fifo_%d", s_is_kid ? (int)getppid() : (int)getpid());
+	char buf[PATH_MAX];
+    const char *tmpdir = s_tmpdir.empty() ? "/tmp" : s_tmpdir.c_str();
+    snprintf(buf, sizeof(buf), "%s/tgstat_fifo_%d", tmpdir, s_is_kid ? (int)getppid() : (int)getpid());
 	return buf;
 }
 
@@ -375,6 +378,22 @@ bool TGStat::wait_for_kid(int millisecs)
             return false;
         }
 
+        // Safety check: verify children are still alive
+        for (vector<pid_t>::iterator ipid = s_running_pids.begin(); ipid != s_running_pids.end(); ) {
+            if (kill(*ipid, 0) == -1 && errno == ESRCH) {
+                vdebug("Child process %d no longer exists but was not reaped by waitpid\n", *ipid);
+                swap(*ipid, s_running_pids.back());
+                s_running_pids.pop_back();
+            } else {
+                ++ipid;
+            }
+        }
+
+        if (s_running_pids.empty() || num_running_pids > s_running_pids.size()) {
+            vdebug("still running %ld child processes (detected via kill)\n", s_running_pids.size());
+            return false;
+        }
+
         vdebug("still running %ld child processes (%d, ...)\n", s_running_pids.size(), s_running_pids.front());
 
         if (nanosleep(&timeout, &remaining))
@@ -403,6 +422,23 @@ bool TGStat::wait_for_kids(int millisecs)
 
         if (s_running_pids.empty()) {
             vdebug("No more running child processes\n");
+            return false;
+        }
+
+        // Safety check: verify that all children we're waiting for are still alive.
+        // This handles edge cases where waitpid might not reap a child (e.g. signal race conditions).
+        for (vector<pid_t>::iterator ipid = s_running_pids.begin(); ipid != s_running_pids.end(); ) {
+            if (kill(*ipid, 0) == -1 && errno == ESRCH) {
+                vdebug("Child process %d no longer exists but was not reaped by waitpid\n", *ipid);
+                swap(*ipid, s_running_pids.back());
+                s_running_pids.pop_back();
+            } else {
+                ++ipid;
+            }
+        }
+
+        if (s_running_pids.empty()) {
+            vdebug("No more running child processes (detected via kill)\n");
             return false;
         }
 
@@ -538,6 +574,19 @@ void TGStat::load_options()
         m_num_processes = min(m_num_processes, num_cores);
     } else
         m_num_processes = num_cores;
+
+    // Determine temporary directory for FIFO files.
+    // Priority: tgs_tmpdir R option > TMPDIR env var > /tmp
+    rvar = Rf_GetOption1(Rf_install("tgs_tmpdir"));
+    if (Rf_isString(rvar) && Rf_xlength(rvar) == 1) {
+        s_tmpdir = CHAR(STRING_ELT(rvar, 0));
+    } else {
+        const char *env_tmpdir = getenv("TMPDIR");
+        if (env_tmpdir && env_tmpdir[0])
+            s_tmpdir = env_tmpdir;
+        else
+            s_tmpdir = "/tmp";
+    }
 }
 
 void TGStat::rnd_seed(uint64_t seed)

--- a/src/tgstat.h
+++ b/src/tgstat.h
@@ -223,6 +223,7 @@ protected:
     static vector<pid_t>        s_running_pids;
     static Shm                 *s_shm;
     static int                  s_fifo_fd;
+    static string               s_tmpdir;
 
 	SEXP                        m_env;
 	mode_t                      m_old_umask;

--- a/tests/testthat/test-cor-knn.R
+++ b/tests/testthat/test-cor-knn.R
@@ -1,0 +1,223 @@
+test_that("tgs_cor_knn returns correct top-k correlations", {
+    set.seed(60427)
+    x <- matrix(rnorm(200), nrow = 20, ncol = 10)
+    knn <- 3
+
+    # Get knn result
+    res <- tgs_cor_knn(x, NULL, knn)
+    expect_s3_class(res, "data.frame")
+    expect_named(res, c("col1", "col2", "cor", "rank"))
+
+    # Verify: for each column, exactly knn neighbors are returned
+    counts <- table(res$col1)
+    expect_true(all(counts == knn))
+
+    # Verify against full correlation + manual knn selection
+    full_cor <- tgs_cor(x, tidy = TRUE)
+    for (col in unique(res$col1)) {
+        knn_res <- res[res$col1 == col, ]
+        # Get top-k from full correlation for this column
+        col_cors <- full_cor[full_cor$col1 == col | full_cor$col2 == col, ]
+        # Normalize to always have our target in col1
+        col_cors_norm <- data.frame(
+            other = ifelse(col_cors$col1 == col, col_cors$col2, col_cors$col1),
+            cor = col_cors$cor
+        )
+        col_cors_sorted <- col_cors_norm[order(-col_cors_norm$cor), ]
+        top_k <- head(col_cors_sorted, knn)
+
+        # The correlations should match (order may differ within same rank)
+        expect_equal(sort(knn_res$cor, decreasing = TRUE), sort(top_k$cor, decreasing = TRUE), tolerance = 1e-10)
+    }
+})
+
+test_that("tgs_cor_knn ranks are correct", {
+    set.seed(60427)
+    x <- matrix(rnorm(200), nrow = 20, ncol = 10)
+    knn <- 3
+
+    res <- tgs_cor_knn(x, NULL, knn)
+
+    # Ranks within each column should be 1:knn
+    for (col in unique(res$col1)) {
+        ranks <- sort(res$rank[res$col1 == col])
+        expect_equal(ranks, 1:knn)
+    }
+
+    # Higher correlation should have lower rank (rank 1 = highest)
+    for (col in unique(res$col1)) {
+        col_res <- res[res$col1 == col, ]
+        col_res <- col_res[order(col_res$rank), ]
+        expect_true(all(diff(col_res$cor) <= 0))
+    }
+})
+
+test_that("tgs_cor_knn works with cross-correlation", {
+    set.seed(60427)
+    x <- matrix(rnorm(200), nrow = 20, ncol = 10)
+    y <- matrix(rnorm(100), nrow = 20, ncol = 5)
+    knn <- 2
+
+    res <- tgs_cor_knn(x, y, knn)
+    expect_s3_class(res, "data.frame")
+    expect_named(res, c("col1", "col2", "cor", "rank"))
+
+    # col1 should reference columns in x, col2 columns in y
+    expect_true(all(res$col1 %in% seq_len(ncol(x))))
+    expect_true(all(res$col2 %in% seq_len(ncol(y))))
+
+    # Each column in x should have knn neighbors
+    counts <- table(res$col1)
+    expect_true(all(counts == knn))
+})
+
+test_that("tgs_cor_knn Spearman mode works", {
+    set.seed(60427)
+    x <- matrix(rnorm(200), nrow = 20, ncol = 10)
+    knn <- 3
+
+    res_pearson <- tgs_cor_knn(x, NULL, knn, spearman = FALSE)
+    res_spearman <- tgs_cor_knn(x, NULL, knn, spearman = TRUE)
+
+    # Results should differ (different correlation methods)
+    expect_false(identical(res_pearson$cor, res_spearman$cor))
+
+    # Both should be valid data frames
+    expect_s3_class(res_spearman, "data.frame")
+    expect_named(res_spearman, c("col1", "col2", "cor", "rank"))
+})
+
+test_that("tgs_cor_knn pairwise.complete.obs works with NAs", {
+    set.seed(60427)
+    x <- matrix(rnorm(200), nrow = 20, ncol = 10)
+    x[1, 1] <- NA
+    x[5, 3] <- NA
+    x[10, 7] <- NA
+    knn <- 3
+
+    # Without pairwise.complete.obs, NAs propagate
+    # (columns with any NA would have NA correlations)
+    res_pco <- tgs_cor_knn(x, NULL, knn, pairwise.complete.obs = TRUE)
+    expect_s3_class(res_pco, "data.frame")
+    expect_true(all(!is.na(res_pco$cor)))
+})
+
+test_that("tgs_cor_knn threshold filters results", {
+    set.seed(60427)
+    x <- matrix(rnorm(200), nrow = 20, ncol = 10)
+    knn <- 5
+    threshold <- 0.3
+
+    res <- tgs_cor_knn(x, NULL, knn, threshold = threshold)
+    # All returned correlations should be above threshold
+    expect_true(all(abs(res$cor) >= threshold))
+})
+
+test_that("tgs_cor_knn knn=1 returns single neighbor per column", {
+    set.seed(60427)
+    x <- matrix(rnorm(200), nrow = 20, ncol = 10)
+
+    res <- tgs_cor_knn(x, NULL, knn = 1)
+    counts <- table(res$col1)
+    expect_true(all(counts == 1))
+    expect_true(all(res$rank == 1))
+})
+
+test_that("tgs_cor_knn handles knn larger than available columns", {
+    set.seed(60427)
+    x <- matrix(rnorm(60), nrow = 20, ncol = 3)
+
+    # knn = 2 (max possible for 3 columns: each column can have at most 2 neighbors)
+    res <- tgs_cor_knn(x, NULL, knn = 2)
+    expect_s3_class(res, "data.frame")
+    counts <- table(res$col1)
+    expect_true(all(counts == 2))
+})
+
+test_that("tgs_cor_knn works with single process", {
+    set.seed(60427)
+    x <- matrix(rnorm(200), nrow = 20, ncol = 10)
+    knn <- 3
+
+    old_opt <- getOption("tgs_max.processes")
+    options(tgs_max.processes = 1)
+    on.exit(options(tgs_max.processes = old_opt))
+
+    res <- tgs_cor_knn(x, NULL, knn)
+    expect_s3_class(res, "data.frame")
+    expect_equal(nrow(res), ncol(x) * knn)
+})
+
+test_that("tgs_cor_knn works with multiple processes", {
+    set.seed(60427)
+    x <- matrix(rnorm(200), nrow = 20, ncol = 10)
+    knn <- 3
+
+    old_opt <- getOption("tgs_max.processes")
+    options(tgs_max.processes = 4)
+    on.exit(options(tgs_max.processes = old_opt))
+
+    res <- tgs_cor_knn(x, NULL, knn)
+    expect_s3_class(res, "data.frame")
+    expect_equal(nrow(res), ncol(x) * knn)
+})
+
+test_that("tgs_cor_knn single vs multi process gives same results", {
+    set.seed(60427)
+    x <- matrix(rnorm(200), nrow = 20, ncol = 10)
+    knn <- 3
+
+    old_opt <- getOption("tgs_max.processes")
+
+    options(tgs_max.processes = 1)
+    res_single <- tgs_cor_knn(x, NULL, knn)
+
+    options(tgs_max.processes = 4)
+    res_multi <- tgs_cor_knn(x, NULL, knn)
+
+    options(tgs_max.processes = old_opt)
+
+    # Sort both for comparison
+    res_single <- res_single[order(res_single$col1, res_single$rank), ]
+    res_multi <- res_multi[order(res_multi$col1, res_multi$rank), ]
+    rownames(res_single) <- NULL
+    rownames(res_multi) <- NULL
+
+    expect_equal(res_single, res_multi)
+})
+
+test_that("tgs_cor_knn rejects invalid inputs", {
+    set.seed(60427)
+    x <- matrix(rnorm(100), nrow = 10)
+
+    # Non-numeric matrix
+    expect_error(tgs_cor_knn(matrix(letters[1:20], nrow = 4), NULL, 2))
+
+    # Invalid knn
+    expect_error(tgs_cor_knn(x, NULL, -1))
+    expect_error(tgs_cor_knn(x, NULL, 0))
+    expect_error(tgs_cor_knn(x, NULL, 1.5))
+})
+
+test_that("tgs_cor_knn with integer matrix works", {
+    set.seed(60427)
+    x <- matrix(sample(1:100, 200, replace = TRUE), nrow = 20, ncol = 10)
+    knn <- 3
+
+    res <- tgs_cor_knn(x, NULL, knn)
+    expect_s3_class(res, "data.frame")
+    expect_equal(nrow(res), ncol(x) * knn)
+})
+
+test_that("tgs_cor_knn with named columns preserves names", {
+    set.seed(60427)
+    x <- matrix(rnorm(200), nrow = 20, ncol = 10)
+    colnames(x) <- paste0("gene", 1:10)
+    knn <- 3
+
+    res <- tgs_cor_knn(x, NULL, knn)
+    expect_s3_class(res, "data.frame")
+    # col1 and col2 should be factor or character with column names
+    expect_true(all(as.character(res$col1) %in% colnames(x)))
+    expect_true(all(as.character(res$col2) %in% colnames(x)))
+})

--- a/tests/testthat/test-tmpdir.R
+++ b/tests/testthat/test-tmpdir.R
@@ -1,0 +1,123 @@
+test_that("tgs_cor works with custom tgs_tmpdir option", {
+    set.seed(60427)
+    x <- matrix(rnorm(100), nrow = 10)
+
+    tmpdir <- tempfile("tgstat_test_tmpdir")
+    dir.create(tmpdir)
+    on.exit(unlink(tmpdir, recursive = TRUE))
+
+    old_opt <- getOption("tgs_tmpdir")
+    options(tgs_tmpdir = tmpdir)
+    on.exit(options(tgs_tmpdir = old_opt), add = TRUE)
+
+    res <- tgs_cor(x)
+    expect_equal(res, cor(x))
+})
+
+test_that("tgs_cor_knn works with custom tgs_tmpdir option", {
+    set.seed(60427)
+    x <- matrix(rnorm(200), nrow = 20, ncol = 10)
+    knn <- 3
+
+    tmpdir <- tempfile("tgstat_test_tmpdir")
+    dir.create(tmpdir)
+    on.exit(unlink(tmpdir, recursive = TRUE))
+
+    old_opt <- getOption("tgs_tmpdir")
+    options(tgs_tmpdir = tmpdir)
+    on.exit(options(tgs_tmpdir = old_opt), add = TRUE)
+
+    res <- tgs_cor_knn(x, NULL, knn)
+    expect_s3_class(res, "data.frame")
+    expect_equal(nrow(res), ncol(x) * knn)
+})
+
+test_that("tgs_dist works with custom tgs_tmpdir option", {
+    set.seed(60427)
+    x <- matrix(rnorm(100), nrow = 10)
+
+    tmpdir <- tempfile("tgstat_test_tmpdir")
+    dir.create(tmpdir)
+    on.exit(unlink(tmpdir, recursive = TRUE))
+
+    old_opt <- getOption("tgs_tmpdir")
+    options(tgs_tmpdir = tmpdir)
+    on.exit(options(tgs_tmpdir = old_opt), add = TRUE)
+
+    res <- tgs_dist(x)
+    expect_equal(as.matrix(res), as.matrix(dist(x)))
+})
+
+test_that("TMPDIR env var is respected when tgs_tmpdir option is not set", {
+    set.seed(60427)
+    x <- matrix(rnorm(100), nrow = 10)
+
+    tmpdir <- tempfile("tgstat_test_tmpdir")
+    dir.create(tmpdir)
+    on.exit(unlink(tmpdir, recursive = TRUE))
+
+    old_opt <- getOption("tgs_tmpdir")
+    old_env <- Sys.getenv("TMPDIR", unset = NA)
+
+    options(tgs_tmpdir = NULL)
+    Sys.setenv(TMPDIR = tmpdir)
+    on.exit(
+        {
+            options(tgs_tmpdir = old_opt)
+            if (is.na(old_env)) Sys.unsetenv("TMPDIR") else Sys.setenv(TMPDIR = old_env)
+        },
+        add = TRUE
+    )
+
+    res <- tgs_cor(x)
+    expect_equal(res, cor(x))
+})
+
+test_that("tgs_tmpdir option takes priority over TMPDIR env var", {
+    set.seed(60427)
+    x <- matrix(rnorm(200), nrow = 20, ncol = 10)
+    knn <- 3
+
+    tmpdir1 <- tempfile("tgstat_test_opt")
+    tmpdir2 <- tempfile("tgstat_test_env")
+    dir.create(tmpdir1)
+    dir.create(tmpdir2)
+    on.exit(unlink(c(tmpdir1, tmpdir2), recursive = TRUE))
+
+    old_opt <- getOption("tgs_tmpdir")
+    old_env <- Sys.getenv("TMPDIR", unset = NA)
+
+    # Set both: option should win
+    options(tgs_tmpdir = tmpdir1)
+    Sys.setenv(TMPDIR = tmpdir2)
+    on.exit(
+        {
+            options(tgs_tmpdir = old_opt)
+            if (is.na(old_env)) Sys.unsetenv("TMPDIR") else Sys.setenv(TMPDIR = old_env)
+        },
+        add = TRUE
+    )
+
+    res <- tgs_cor_knn(x, NULL, knn)
+    expect_s3_class(res, "data.frame")
+    expect_equal(nrow(res), ncol(x) * knn)
+})
+
+test_that("multiprocess works with custom tgs_tmpdir", {
+    set.seed(60427)
+    x <- matrix(rnorm(200), nrow = 20, ncol = 10)
+    knn <- 3
+
+    tmpdir <- tempfile("tgstat_test_tmpdir")
+    dir.create(tmpdir)
+    on.exit(unlink(tmpdir, recursive = TRUE))
+
+    old_tmpdir_opt <- getOption("tgs_tmpdir")
+    old_proc_opt <- getOption("tgs_max.processes")
+    options(tgs_tmpdir = tmpdir, tgs_max.processes = 4)
+    on.exit(options(tgs_tmpdir = old_tmpdir_opt, tgs_max.processes = old_proc_opt), add = TRUE)
+
+    res <- tgs_cor_knn(x, NULL, knn)
+    expect_s3_class(res, "data.frame")
+    expect_equal(nrow(res), ncol(x) * knn)
+})


### PR DESCRIPTION
## Summary

- **Configurable FIFO temp directory** (#17): `get_fifo_name()` now respects `options(tgs_tmpdir = "/path")` and the `TMPDIR` environment variable instead of hardcoding `/tmp`. Priority: R option > env var > `/tmp`.
- **Child-process liveness check** (#18): `wait_for_kid()` and `wait_for_kids()` now verify children are still alive via `kill(pid, 0)`. If a child is gone but wasn't reaped by `waitpid` (signal race condition), it's removed from the tracking list, preventing infinite waits.
- **71 new tests**: Comprehensive `tgs_cor_knn` coverage (62 tests) and tmpdir configuration tests (9 tests). Total: 87 tests, all passing.

Closes #17, closes #18

## Test plan

- [x] `devtools::test()` — 87 tests pass (0 failures)
- [x] `devtools::check()` — 0 errors, 0 new warnings/notes
- [x] Single-process and multi-process `tgs_cor_knn` give identical results
- [x] Custom tmpdir works for `tgs_cor`, `tgs_cor_knn`, and `tgs_dist`
- [x] `TMPDIR` env var fallback works when `tgs_tmpdir` option is unset
- [x] R option takes priority over env var