### PR TITLE
fix: replace non-API Rf_findVar with R_getVar

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@
 ^\.vscode\.*
 ^\.github$
 ^conda-recipe$
+^\.claude$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tgstat
 Title: Amos Tanay's Group High Performance Statistical Utilities
-Version: 2.3.30
+Version: 2.3.31
 Authors@R: c(
     person("Michael", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tgstat
 Title: Amos Tanay's Group High Performance Statistical Utilities
-Version: 2.3.31
+Version: 2.3.32
 Authors@R: c(
     person("Michael", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# tgstat 2.3.31
+
+* Replaced non-API C entry point `Rf_findVar` with `R_getVar` for R 4.6.0 compatibility.
+
 # tgstat 2.3.30
 
 * FIFO temp directory is now configurable via `options(tgs_tmpdir = "/path")` or the `TMPDIR` environment variable, instead of being hardcoded to `/tmp`. Fixes permission errors on systems where `/tmp` is restricted (#17).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
-# tgstat 2.3.31
+# tgstat 2.3.32
 
 * Replaced non-API C entry point `Rf_findVar` with `R_getVar` for R 4.6.0 compatibility.
+* Added `.claude` to `.Rbuildignore`.
 
 # tgstat 2.3.30
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -5,3 +5,4 @@
 ## Changes
 
 * Replaced non-API C entry point `Rf_findVar` with `R_getVar`.
+* Added `.claude` to `.Rbuildignore`.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -4,9 +4,4 @@
 
 ## Changes
 
-* Removed non-API calls to R: `Rf_GetOption`.
-
-
-
-
-
+* Replaced non-API C entry point `Rf_findVar` with `R_getVar`.

--- a/src/tgstat.cpp
+++ b/src/tgstat.cpp
@@ -35,6 +35,18 @@
 #include <Rembedded.h>
 #include <R_ext/Parse.h>
 
+// Backward-compatible shim for R < 4.5.0
+#include <Rversion.h>
+#if R_VERSION < R_Version(4, 5, 0)
+static inline SEXP R_getVar(SEXP sym, SEXP rho, Rboolean inherits) {
+    SEXP val = inherits ? Rf_findVar(sym, rho) : Rf_findVarInFrame(sym, rho);
+    if (val == R_UnboundValue)
+        Rf_error("object '%s' not found", CHAR(PRINTNAME(sym)));
+    MARK_NOT_MUTABLE(val);
+    return val;
+}
+#endif
+
 #ifdef length
 #undef length
 #endif
@@ -799,7 +811,7 @@ void runprotect_all()
 const char *get_groot(SEXP envir)
 {
 	// no need to protect the returned value
-	SEXP groot = Rf_findVar(Rf_install("GROOT"), envir);
+	SEXP groot = R_getVar(Rf_install("GROOT"), envir, TRUE);
 
 	if (!Rf_isString(groot))
 		verror("GROOT variable does not exist");
@@ -810,7 +822,7 @@ const char *get_groot(SEXP envir)
 const char *get_glib_dir(SEXP envir)
 {
 	// no need to protect the returned value
-	SEXP glibdir = Rf_findVar(Rf_install(".GLIBDIR"), envir);
+	SEXP glibdir = R_getVar(Rf_install(".GLIBDIR"), envir, TRUE);
 
 	if (!Rf_isString(glibdir))
 		verror(".GLIBDIR variable does not exist");

--- a/src/tgstat.cpp
+++ b/src/tgstat.cpp
@@ -811,7 +811,7 @@ void runprotect_all()
 const char *get_groot(SEXP envir)
 {
 	// no need to protect the returned value
-	SEXP groot = R_getVar(Rf_install("GROOT"), envir, TRUE);
+	SEXP groot = R_getVar(Rf_install("GROOT"), envir, (Rboolean)TRUE);
 
 	if (!Rf_isString(groot))
 		verror("GROOT variable does not exist");
@@ -822,7 +822,7 @@ const char *get_groot(SEXP envir)
 const char *get_glib_dir(SEXP envir)
 {
 	// no need to protect the returned value
-	SEXP glibdir = R_getVar(Rf_install(".GLIBDIR"), envir, TRUE);
+	SEXP glibdir = R_getVar(Rf_install(".GLIBDIR"), envir, (Rboolean)TRUE);
 
 	if (!Rf_isString(glibdir))
 		verror(".GLIBDIR variable does not exist");


### PR DESCRIPTION
## Summary
- Replaced 2 `Rf_findVar` calls with `R_getVar` in `src/tgstat.cpp`
- Added backward-compatibility shim for R < 4.5.0
- CRAN compliance fix for R 4.6.0 (deadline: April 9, 2026)

## Test plan
- [ ] CI R CMD check passes
- [ ] Package compiles successfully